### PR TITLE
Add PostgreSQL task to configure pg_hba.conf

### DIFF
--- a/install-anet.yml
+++ b/install-anet.yml
@@ -63,6 +63,11 @@
         name: postgresql
         tasks_from: install
 
+    # Configure access rules
+    - import_role:
+        name: postgresql
+        tasks_from: grant-access-rules
+
     # Install ANET
     - import_role:
         name: anet

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -1,3 +1,4 @@
 remote_rpm_folder: '{{remote_artifact_folder}}'
 postgresql_major_version: 12
 postgresql_rpm_version: 12.4-1PGDG
+postgresql_hba_conf_path: '/var/lib/pgsql/{{postgresql_major_version}}/data/pg_hba.conf'

--- a/roles/postgresql/tasks/grant-access-rules.yml
+++ b/roles/postgresql/tasks/grant-access-rules.yml
@@ -1,0 +1,62 @@
+# Configure PostgreSQl pg_hba.conf
+
+- name: '"local" is for Unix domain socket connections only'
+  become: yes
+  postgresql_pg_hba:
+    dest: '{{postgresql_hba_conf_path}}'
+    contype: local
+    users: all
+    databases: all
+    method: peer
+    create: true
+
+- name: 'IPv4 local connections to anet DB:'
+  become: yes
+  postgresql_pg_hba:
+    dest: '{{postgresql_hba_conf_path}}'
+    contype: host
+    users: all
+    source: 127.0.0.1/32
+    databases: anet
+    method: md5
+    create: true
+
+- name: 'IPv6 local connections:'
+  become: yes
+  postgresql_pg_hba:
+    dest: '{{postgresql_hba_conf_path}}'
+    contype: host
+    users: all
+    source: ::1/128
+    databases: all
+    method: ident
+    create: true
+
+- name: 'Allow replication connections from localhost, by a user with the replication privilege, local access'
+  become: yes
+  postgresql_pg_hba:
+    dest: '{{postgresql_hba_conf_path}}'
+    contype: local
+    users: all
+    databases: replication
+    method: peer
+
+- name: 'Allow replication connections from localhost, by a user with the replication privilege, host IPv4'
+  become: yes
+  postgresql_pg_hba:
+    dest: '{{postgresql_hba_conf_path}}'
+    contype: host
+    users: all
+    source: 127.0.0.1/32
+    databases: replication
+    method: ident
+
+- name: 'Allow replication connections from localhost, by a user with the replication privilege, host IPv6'
+  become: yes
+  postgresql_pg_hba:
+    dest: '{{postgresql_hba_conf_path}}'
+    contype: host
+    users: all
+    source: ::1/128
+    databases: replication
+    method: ident


### PR DESCRIPTION
Add task `grant-access-rules` to the PostgreSQL role to configure `pg_hba.conf`.

References:
* https://docs.ansible.com/ansible/latest/modules/postgresql_pg_hba_module.html

After this tasks, on the target machine:
```shell-script
cat /var/lib/pgsql/12/data/pg_hba.conf
```
outputs
```

local	replication	all	peer
local	all	all	peer
host	replication	all	127.0.0.1/32	ident
host	replication	all	::1/128	ident
host	anet	all	127.0.0.1/32	md5
host	all	all	::1/128	ident
```

