### PR TITLE
Register Keycloak systemd script

### DIFF
--- a/roles/keycloak/tasks/install.yml
+++ b/roles/keycloak/tasks/install.yml
@@ -9,3 +9,12 @@
   unarchive:
     src: '{{local_artifact_folder}}/keycloak-{{keycloak_version}}.tar.gz'
     dest: '{{keycloak_installation_folder}}'
+
+- name: 'Register Keycloak systemd script'
+  become: yes
+  template:
+    src: anet.service.j2
+    dest: '/usr/lib/systemd/system/anet.service'
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx

--- a/roles/keycloak/tasks/keycloak.service.j2
+++ b/roles/keycloak/tasks/keycloak.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Keycloak service
+After=network.target
+[Service]
+Type=idle
+Environment=JAVA_HOME=/usr/java/default JBOSS_HOME=/opt/anet/keycloak-{{keycloak_version}} JAVA=/usr/java/default/bin/java JBOSS_LOG_DIR=/opt/anet/logs
+ExecStart=/opt/anet/keycloak-server.sh
+TimeoutStartSec=600
+TimeoutStopSec=600


### PR DESCRIPTION
Register [Keycloak](https://www.keycloak.org/) [systemd](https://nl.wikipedia.org/wiki/Systemd) script.

Uses the default JRE path (`/usr/java/default`).