### PR TITLE
Configure Keycloak clients using keycloak_client module

### DIFF
--- a/install-anet.yml
+++ b/install-anet.yml
@@ -65,8 +65,6 @@
         name: keycloak
         tasks_from: start
 
-    # Add the ANET REALM is missing, should done manually
-
     # Install NGINX
     - import_role:
         name: nginx
@@ -81,6 +79,13 @@
     - import_role:
         name: nginx
         tasks_from: generate-self-signed
+
+    # Add the ANET REALM is missing, should done manually
+
+    # Configure Keycloak clients
+    - import_role:
+        name: keycloak
+        tasks_from: client-config
 
     # NGINX: Start
     - import_role:

--- a/install-anet.yml
+++ b/install-anet.yml
@@ -97,6 +97,11 @@
         name: nginx
         tasks_from: firewall-open
 
+    # Configure Keycloak clients
+    - import_role:
+        name: keycloak
+        tasks_from: client-config
+
     # Install PostgreSQL 12
     - import_role:
         name: postgresql

--- a/install-anet.yml
+++ b/install-anet.yml
@@ -22,6 +22,8 @@
 
     anet_db_host: 'localhost'
 
+    anet_fqhn: '{{ hostvars.{{ inventory_hostname }}.ansible_ssh_host }}' # ToDo
+
     ANET_DB_NAME: 'anet'
 
     # ANET anet.yml variables

--- a/roles/anet/tasks/install.yml
+++ b/roles/anet/tasks/install.yml
@@ -1,7 +1,7 @@
 - set_fact:
     anet_rpm_dependencies:
       - '{{ anet_rpm }}'
-    ANET_PORT: : '{{ anet_http_port }}'
+    ANET_PORT: '{{ anet_http_port }}'
 
 - name: Transfer ANET dependencies to target machine
   become: yes

--- a/roles/anet/tasks/install.yml
+++ b/roles/anet/tasks/install.yml
@@ -1,7 +1,7 @@
 - set_fact:
     anet_rpm_dependencies:
       - '{{ anet_rpm }}'
-    ANET_PORT: '{{ anet_http_port }}'
+    ANET_PORT: : '{{ anet_http_port }}'
 
 - name: Transfer ANET dependencies to target machine
   become: yes

--- a/roles/anet/templates/anet.yml.j2
+++ b/roles/anet/templates/anet.yml.j2
@@ -53,7 +53,7 @@ keycloakConfiguration:
   enable-basic-auth: true
   disable-trust-manager: true # Used to access KeyCloak within localhost
   credentials:
-    secret: 12869b4c-74ac-43f9-b71e-ff74e07babf9
+    secret: {{ anet_keycloak_key_server }}
 
 ########################################################
 ### The below is the default Dropwizard Configuration

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -5,3 +5,4 @@ keycloak_https_port: 9443
 keycloak_application_folder: '{{keycloak_installation_folder}}/keycloak-{{keycloak_version}}'
 keycloak_user: 'admin'
 keycloak_password: 'admin'
+keycloak_auth_url: 'http://localhost:9080/auth'

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -5,4 +5,5 @@ keycloak_https_port: 9443
 keycloak_application_folder: '{{keycloak_installation_folder}}/keycloak-{{keycloak_version}}'
 keycloak_user: 'admin'
 keycloak_password: 'admin'
-keycloak_auth_url: 'http://localhost:9080/auth'
+keycloak_auth_url: 'http://localhost:{{ keycloak_http_port }}/auth'
+keycloak_anet_realm: 'ANET-Realm'

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -6,4 +6,5 @@ keycloak_application_folder: '{{keycloak_installation_folder}}/keycloak-{{keyclo
 keycloak_user: 'admin'
 keycloak_password: 'admin'
 keycloak_auth_url: 'http://localhost:{{ keycloak_http_port }}/auth'
+keycloak_api_realm: 'master'
 keycloak_anet_realm: 'ANET-Realm'

--- a/roles/keycloak/tasks/client-config.yml
+++ b/roles/keycloak/tasks/client-config.yml
@@ -6,7 +6,7 @@
     module: keycloak_client
     auth_client_id: admin-cli
     auth_keycloak_url: '{{ keycloak_auth_url }}'
-    auth_realm: master
+    auth_realm: '{{ keycloak_anet_realm }}'
     auth_username: '{{ keycloak_user }}'
     auth_password: '{{ keycloak_password }}'
     state: present
@@ -38,7 +38,7 @@
     module: keycloak_client
     auth_client_id: admin-cli
     auth_keycloak_url: '{{ keycloak_auth_url }}'
-    auth_realm: master
+    auth_realm: '{{ keycloak_anet_realm }}'
     auth_username: '{{ keycloak_user }}'
     auth_password: '{{ keycloak_password }}'
     state: present

--- a/roles/keycloak/tasks/client-config.yml
+++ b/roles/keycloak/tasks/client-config.yml
@@ -15,8 +15,9 @@
     implicit_flow_enabled: no
     standard_flow_enabled: yes
     protocol: openid-connect
-    public_client: no # Access Type = confidential
+    public_client: no
     root_url: http://localhost:8080
+    service_accounts_enabled: yes
     base_url: /
     redirect_uris:
       - http://localhost:8180/*
@@ -48,7 +49,7 @@
     protocol: openid-connect
     public_client: yes # Access Type = confidential
     root_url: http://localhost:8080
-    service_accounts_enabled: yes
+    service_accounts_enabled: no
     base_url: /
     redirect_uris:
       - http://localhost:8180/*

--- a/roles/keycloak/tasks/client-config.yml
+++ b/roles/keycloak/tasks/client-config.yml
@@ -1,0 +1,64 @@
+- set_fact:
+    anet_keycloak_key_server: "{{ lookup('password', '/dev/null length=32 chars=ascii_letters') }}"
+
+- name: 'Keycloak client: ANET confidential client (used by the server-side)'
+  local_action:
+    module: keycloak_client
+    auth_client_id: admin-cli
+    auth_keycloak_url: '{{ keycloak_auth_url }}'
+    auth_realm: master
+    auth_username: '{{ keycloak_user }}'
+    auth_password: '{{ keycloak_password }}'
+    state: present
+    # ANET-Client
+    client_id: ANET-Client
+    implicit_flow_enabled: no
+    standard_flow_enabled: yes
+    protocol: openid-connect
+    public_client: no # Access Type = confidential
+    root_url: http://localhost:8080
+    base_url: /
+    redirect_uris:
+      - http://localhost:8180/*
+      - http://localhost:3000/*
+      - /*
+    admin_url: ''
+    web_origins:
+      - +
+    secret: '{{ anet_keycloak_key_server }}'
+  register: anet_confidential_client_result
+
+- debug:
+    var: anet_confidential_client_result
+    verbosity: 2
+
+- name: 'Keycloak client: ANET public client (used by client-side)'
+  local_action:
+    module: keycloak_client
+    auth_client_id: admin-cli
+    auth_keycloak_url: '{{ keycloak_auth_url }}'
+    auth_realm: master
+    auth_username: '{{ keycloak_user }}'
+    auth_password: '{{ keycloak_password }}'
+    state: present
+    # ANET-Client
+    client_id: ANET-Client-public
+    implicit_flow_enabled: no
+    standard_flow_enabled: yes
+    protocol: openid-connect
+    public_client: yes # Access Type = confidential
+    root_url: http://localhost:8080
+    service_accounts_enabled: yes
+    base_url: /
+    redirect_uris:
+      - http://localhost:8180/*
+      - http://localhost:3000/*
+      - /*
+    admin_url: ''
+    web_origins:
+      - +
+  register: anet_public_client_result
+
+- debug:
+    var: anet_public_client_result
+    verbosity: 2

--- a/roles/keycloak/tasks/client-config.yml
+++ b/roles/keycloak/tasks/client-config.yml
@@ -2,11 +2,11 @@
     anet_keycloak_key_server: "{{ lookup('password', '/dev/null length=32 chars=ascii_letters') }}"
 
 - name: 'Keycloak client: ANET confidential client (used by the server-side)'
-  local_action:
-    module: keycloak_client
+  keycloak_client:
+    realm: '{{ keycloak_anet_realm }}'
     auth_client_id: admin-cli
     auth_keycloak_url: '{{ keycloak_auth_url }}'
-    auth_realm: '{{ keycloak_anet_realm }}'
+    auth_realm: '{{ keycloak_api_realm }}' # API realm
     auth_username: '{{ keycloak_user }}'
     auth_password: '{{ keycloak_password }}'
     state: present
@@ -16,12 +16,11 @@
     standard_flow_enabled: yes
     protocol: openid-connect
     public_client: no
-    root_url: http://localhost:8080
+    root_url: 'https://{{ anet_fqhn }}'
     service_accounts_enabled: yes
     base_url: /
     redirect_uris:
-      - http://localhost:8180/*
-      - http://localhost:3000/*
+      - 'http://{{ anet_fqhn }}/*'
       - /*
     admin_url: ''
     web_origins:
@@ -34,11 +33,11 @@
     verbosity: 2
 
 - name: 'Keycloak client: ANET public client (used by client-side)'
-  local_action:
-    module: keycloak_client
+  keycloak_client:
+    realm: '{{ keycloak_anet_realm }}'
     auth_client_id: admin-cli
     auth_keycloak_url: '{{ keycloak_auth_url }}'
-    auth_realm: '{{ keycloak_anet_realm }}'
+    auth_realm: '{{ keycloak_api_realm }}' # API realm
     auth_username: '{{ keycloak_user }}'
     auth_password: '{{ keycloak_password }}'
     state: present
@@ -48,12 +47,11 @@
     standard_flow_enabled: yes
     protocol: openid-connect
     public_client: yes # Access Type = confidential
-    root_url: http://localhost:8080
+    root_url: 'https://{{ anet_fqhn }}'
     service_accounts_enabled: no
     base_url: /
     redirect_uris:
-      - http://localhost:8180/*
-      - http://localhost:3000/*
+      - 'http://{{ anet_fqhn }}/*'
       - /*
     admin_url: ''
     web_origins:

--- a/roles/keycloak/tasks/start.yml
+++ b/roles/keycloak/tasks/start.yml
@@ -3,3 +3,14 @@
   service:
     name: keycloak.service
     state: started
+  register: keycloak_started
+
+- name: Wait for Keycloak HTTP port to listen...
+  wait_for:
+    host: localhost
+    port: '{{ keycloak_http_port }}'
+    delay: 10
+    timeout: 30
+    state: started
+    msg: 'KeyCloak HTTP port {{ keycloak_http_port }} is not listening'
+  when: keycloak_started.changed

--- a/roles/keycloak/tasks/start.yml
+++ b/roles/keycloak/tasks/start.yml
@@ -12,5 +12,5 @@
     delay: 10
     timeout: 30
     state: started
-    msg: 'KeyCloak HTTP port {{ keycloak_http_port }} is not listening'
+    msg: 'Keycloak HTTP port {{ keycloak_http_port }} is not listening'
   when: keycloak_started.changed


### PR DESCRIPTION
- [ ] Configure `ANET-Realm`, requires [Ansible realm support](https://github.com/ansible-collections/community.general/pull/859), created issue: #15
- [x] Configure Keycloak clients, in line with [Setting up Keycloak (user authentication)](https://github.com/NCI-Agency/anet/blob/keycloak-integration/docs/keycloak.md):

  - Creates the server client: "ANET-Client"
  - Creates the public client: "ANET-Client-public"
- Introduces a dependency on [keycloak_client](https://docs.ansible.com/ansible/latest/collections/community/general/keycloak_client_module.html) which is a plugin part of the [community.general collection](https://docs.ansible.com/ansible/latest/collections/community/general/).
- [x] Move the internal Keycloak HTTP ports configuration to the Ansible Keycloak role
