### PR TITLE
Fix HTTPS access to ANET after installation

### DIFF
--- a/roles/anet/defaults/main.yml
+++ b/roles/anet/defaults/main.yml
@@ -9,15 +9,17 @@ remote_rpm_folder: '{{remote_artifact_folder}}'
 
 postgresql_major_version: 12
 
+ANET_PORT: '{{anet_http_port}}'
+
 ANET_DB_NAME: 'testAnet'
 
-ANET_SMTP_SERVER: 'localhost'
-ANET_SMTP_PORT: '1025'
+ANET_SMTP_SERVER: localhost
+ANET_SMTP_PORT: 587
 ANET_SMTP_USERNAME: ''
 ANET_SMTP_PASSWORD: ''
 ANET_SMTP_SSLTRUST: ''
-ANET_SMTP_STARTTLS: 'true'
-ANET_SMTP_DISABLE: 'true'
+ANET_SMTP_STARTTLS: true
+ANET_SMTP_DISABLE: true
 
 ANET_DB_DRIVER: 'org.postgresql.Driver'
 ANET_DB_USERNAME: 'anetTestUser'

--- a/roles/anet/templates/anet.yml.j2
+++ b/roles/anet/templates/anet.yml.j2
@@ -43,14 +43,14 @@ emailFromAddr: "Anet Testing <hunter+anet@dds.mil>"
 serverUrl: "http://localhost:3000"
 
 keycloakConfiguration:
-  realm: ANET-Realm
+  realm:  {{ keycloak_anet_realm }}
   auth-server-url: 'https://{{ anet_fqhn }}/auth'
   ssl-required: none
   register-node-at-startup: true
   register-node-period: 600
   resource: ANET-Client
   show-logout-link: true
-  enable-basic-auth: true
+  enable-basic-auth: false
   disable-trust-manager: true # Used to access KeyCloak within localhost
   credentials:
     secret: {{ anet_keycloak_key_server }}

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -15,3 +15,13 @@
   service:
     name: nginx
     enabled: yes
+
+- name: Set SE-Linux policy to allow NGINX can connect via HTTP to ANET
+  become: yes
+  command:
+    argv:
+      - setsebool
+      - -P
+      - httpd_can_network_connect
+      - on
+


### PR DESCRIPTION
- Disable basic-auth in anet.yml
- Set default SMTP port to 587
- Adjust SE-Linux policy to allow NGINX to connect to ANET