### PR TITLE
Integrate pgAdmin 

### DIFF
--- a/install-anet.yml
+++ b/install-anet.yml
@@ -75,29 +75,29 @@
         name: keycloak
         tasks_from: start
 
-    # Install NGINX
+    # Install Apache as reverse proxy
     - import_role:
-        name: nginx
+        name: apache
         tasks_from: install
 
-    # Configure NGINX
+    # Generate self-signed certificate for Apache
     - import_role:
-        name: nginx
-        tasks_from: configure
-
-    # Generate self signed certificates
-    - import_role:
-        name: nginx
+        name: apache
         tasks_from: generate-self-signed
 
-    # NGINX: Start
+    # Configure Apache
     - import_role:
-        name: nginx
+        name: apache
+        tasks_from: configure
+
+    # Start Apache
+    - import_role:
+        name: apache
         tasks_from: start
 
-    # NGINX: Open firewall for NGINX HTTP/HTTPS service
+    # Open firewall for Apache HTTP/HTTPS service
     - import_role:
-        name: nginx
+        name: apache
         tasks_from: firewall-open
 
     # Configure Keycloak clients

--- a/install-anet.yml
+++ b/install-anet.yml
@@ -90,6 +90,11 @@
         name: apache
         tasks_from: configure
 
+    # Install pgAdmin
+    - import_role:
+        name: pgadmin
+        tasks_from: install
+
     # Start Apache
     - import_role:
         name: apache

--- a/roles/apache/defaults/main.yml
+++ b/roles/apache/defaults/main.yml
@@ -1,0 +1,15 @@
+mod_wsgi_rpm: mod_wsgi-3.4-18.el7.x86_64.rpm
+
+httpd_server_name: '{{ anet_fqhn }}'
+
+httpd_path_certificates: /etc/pki/tls/certs
+
+python_ssl_rpm_version: '0.15.1-1.el7'
+
+# Certificate path
+httpd_path_ssl_certificate: /etc/pki/tls/certs/localhost.crt
+httpd_path_ssl_certificate_key: /etc/pki/tls/private/localhost.key
+
+httpd_path_ssl_csr: '{{ httpd_path_certificates }}/{{ inventory_hostname }}.csr'
+
+remote_rpm_folder: '{{ remote_artifact_folder }}'

--- a/roles/apache/install-pyhton-cryptography.yml
+++ b/roles/apache/install-pyhton-cryptography.yml
@@ -1,0 +1,17 @@
+- name: Ensure RPM folder in setup directory exists
+  become: yes
+  file:
+    path: '{{remote_artifact_folder}}'
+    state: directory
+
+- name: Transfer PyOpenSSL RPM version {{python_ssl_rpm_version}}
+  become: yes
+  copy:
+    src: '{{local_artifact_folder}}/{{python_ssl_rpm_name}}'
+    dest: '{{remote_rpm_folder}}/'
+
+- name: Install PyOpenSSL RPM version {{python_ssl_rpm_version}}
+  become: yes
+  yum:
+    name: '{{remote_rpm_folder}}/{{python_ssl_rpm_name}}'
+    state: present

--- a/roles/apache/tasks/configure.yml
+++ b/roles/apache/tasks/configure.yml
@@ -1,0 +1,24 @@
+- name: 'Remove Apache httpd default welcome page'
+  become: yes
+  file:
+    state: absent
+    path: /etc/httpd/conf.d/welcome.conf
+
+- name: 'Add ssl.conf configuration to Apache'
+  become: yes
+  template:
+    src: ssl.conf
+    dest: /etc/httpd/conf.d/ssl.conf
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+
+- name: Retrieve service information
+  service_facts:
+
+- name: Reload Apache httpd
+  become: yes
+  service:
+    name: 'httpd.service'
+    state: restarted
+  when: ansible_facts.services['httpd.service'].state == 'running'

--- a/roles/apache/tasks/firewall-open.yml
+++ b/roles/apache/tasks/firewall-open.yml
@@ -1,0 +1,23 @@
+- name: Check if firewall is active
+  service_facts:
+  register: firewalld
+
+- name: Permit traffic in public zone for Apache https service
+  become: yes
+  firewalld:
+    zone: public
+    service: https
+    permanent: yes
+    immediate: yes
+    state: enabled
+  when: ansible_facts.services['firewalld.service'].status == 'enabled'
+
+- name: Permit traffic in public zone for Apache http service
+  become: yes
+  firewalld:
+    zone: public
+    service: http
+    permanent: yes
+    immediate: yes
+    state: enabled
+  when: ansible_facts.services['firewalld.service'].status == 'enabled'

--- a/roles/apache/tasks/generate-self-signed.yml
+++ b/roles/apache/tasks/generate-self-signed.yml
@@ -1,0 +1,44 @@
+---
+# --------------------------------------------------------------
+# Generate self-signed certificate
+# --------------------------------------------------------------
+
+- name: Install PyOpenSSL RPM version {{python_ssl_rpm_version}}
+  become: yes
+  yum:
+    name: 'pyOpenSSL-{{python_ssl_rpm_version}}'
+    state: present
+
+- name: Ensure Apache httpd certificate path exist
+  become: yes
+  file:
+    path: '{{ httpd_path_certificates }}'
+    state: directory
+
+- name: 'Generate OpenSSL private keys for {{ httpd_server_name }}'
+  become: yes
+  openssl_privatekey:
+    path: '{{ httpd_path_ssl_certificate_key }}'
+    type: 'RSA'
+    size: 4096
+
+- name: Generate an OpenSSL CSR.
+  become: yes
+  openssl_csr:
+    path: '{{ httpd_path_ssl_csr }}'
+    privatekey_path: '{{ httpd_path_ssl_certificate_key }}'
+    common_name: "{{ httpd_server_name }}"
+    subject_alt_name:
+      - 'IP:{{ ansible_default_ipv4.address }}'
+      - 'DNS:{{ httpd_server_name }}'
+    subject_alt_name_critical: yes
+    organization_name: NATO
+    organizational_unit_name: ANET
+
+- name: 'Generate a Self Signed OpenSSL certificate for {{ httpd_server_name }}'
+  become: yes
+  openssl_certificate:
+    path: '{{ httpd_path_ssl_certificate }}'
+    privatekey_path: '{{ httpd_path_ssl_certificate_key }}'
+    csr_path: '{{ httpd_path_ssl_csr }}'
+    provider: selfsigned

--- a/roles/apache/tasks/install.yml
+++ b/roles/apache/tasks/install.yml
@@ -7,7 +7,7 @@
       - mod_ssl
       - mod_wsgi # Required for pgAdmin
     state: latest
-  register: install_postgresql
+  register: install_httpd
 
 - name: Retrieve service information
   service_facts:

--- a/roles/apache/tasks/install.yml
+++ b/roles/apache/tasks/install.yml
@@ -1,0 +1,36 @@
+- name: 'Install Apache httpd & modules'
+  become: yes
+  yum:
+    name:
+      - httpd
+      - httpd-tools
+      - mod_ssl
+      - mod_wsgi # Required for pgAdmin
+    state: latest
+  register: install_postgresql
+
+- name: Retrieve service information
+  service_facts:
+
+- name: Disable NGINX service
+  become: yes
+  service:
+    name: nginx
+    enabled: no
+  when: ansible_facts.services['nginx.service'] is defined
+
+- name: Enable Apache systemd service
+  become: yes
+  service:
+    name: httpd
+    enabled: yes
+
+- name: Set SE-Linux policy to allow NGINX can connect via HTTP to ANET
+  become: yes
+  command:
+    argv:
+      - setsebool
+      - -P
+      - httpd_can_network_connect
+      - on
+

--- a/roles/apache/tasks/start.yml
+++ b/roles/apache/tasks/start.yml
@@ -1,0 +1,15 @@
+- name: Retrieve service information
+  service_facts:
+
+- name: Stop NGINX systemd service
+  become: yes
+  service:
+    name: nginx
+    state: stopped
+  when: ansible_facts.services['nginx.service'] is defined
+
+- name: Start Apache (httpd) systemd service
+  become: yes
+  service:
+    name: httpd
+    state: started

--- a/roles/apache/templates/proxy.conf.j2
+++ b/roles/apache/templates/proxy.conf.j2
@@ -1,0 +1,6 @@
+<IfModule mod_ssl.c>
+<VirtualHost _default_:443>
+	ServerAdmin webmaster@ssl-tutorials.com
+	ServerName {{ httpd_server_name }}:443
+</VirtualHost>
+</IfModule>

--- a/roles/apache/templates/ssl.conf
+++ b/roles/apache/templates/ssl.conf
@@ -62,16 +62,19 @@ SSLCryptoDevice builtin
 
   ProxyPreserveHost On
 	SSLProxyEngine On
+	RewriteEngine On
 
 	RequestHeader set X-Forwarded-Proto "https"
 	RequestHeader set X-Forwarded-Port "443"
+
+  ProxyPass         /pgadmin4 http://127.0.0.1/pgadmin4
+  ProxyPass         /usr/pgadmin4/web/ http://127.0.0.1/usr/pgadmin4/web/
 
   ProxyPass         /auth/   http://127.0.0.1:{{ keycloak_http_port }}/auth/
   ProxyPassReverse  /auth/   http://127.0.0.1:{{ keycloak_http_port }}/auth/
 
   ProxyPass         /   http://127.0.0.1:8080/
-  ProxyPassReverse  /   http://127.0.0.1:8080/
-
+	ProxyPassReverse  /   http://127.0.0.1:8080/
 
   # Use separate log files for the SSL virtual host; note that LogLevel
   # is not inherited from httpd.conf.

--- a/roles/apache/templates/ssl.conf
+++ b/roles/apache/templates/ssl.conf
@@ -1,0 +1,231 @@
+#
+# When we also provide SSL we have to listen to the
+# the HTTPS port in addition.
+#
+Listen 443 https
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is a internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog exec:/usr/libexec/httpd-ssl-pass-dialog
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism
+#   to use and second the expiring timeout (in seconds).
+SSLSessionCache         shmcb:/run/httpd/sslcache(512000)
+SSLSessionCacheTimeout  300
+
+#   Pseudo Random Number Generator (PRNG):
+#   Configure one or more sources to seed the PRNG of the
+#   SSL library. The seed data should be of good random quality.
+#   WARNING! On some platforms /dev/random blocks if not enough entropy
+#   is available. This means you then cannot use the /dev/random device
+#   because it would lead to very long connection times (as long as
+#   it requires to make more entropy available). But usually those
+#   platforms additionally provide a /dev/urandom device which doesn't
+#   block. So, if available, use this one instead. Read the mod_ssl User
+#   Manual for more details.
+SSLRandomSeed startup file:/dev/urandom  256
+SSLRandomSeed connect builtin
+#SSLRandomSeed startup file:/dev/random  512
+#SSLRandomSeed connect file:/dev/random  512
+#SSLRandomSeed connect file:/dev/urandom 512
+
+#
+# Use "SSLCryptoDevice" to enable any supported hardware
+# accelerators. Use "openssl engine -v" to list supported
+# engine names.  NOTE: If you enable an accelerator and the
+# server does not start, consult the error logs and ensure
+# your accelerator is functioning properly.
+#
+SSLCryptoDevice builtin
+#SSLCryptoDevice ubsec
+
+##
+## SSL Virtual Host Context
+##
+
+<VirtualHost *:443>
+
+  # General setup for the virtual host, inherited from global configuration
+  #DocumentRoot "/var/www/html"
+  #ServerName www.example.com:443
+  ServerName {{ httpd_server_name }}:443
+
+  ProxyPreserveHost On
+	SSLProxyEngine On
+
+	RequestHeader set X-Forwarded-Proto "https"
+	RequestHeader set X-Forwarded-Port "443"
+
+  ProxyPass         /auth/   http://127.0.0.1:{{ keycloak_http_port }}/auth/
+  ProxyPassReverse  /auth/   http://127.0.0.1:{{ keycloak_http_port }}/auth/
+
+  ProxyPass         /   http://127.0.0.1:8080/
+  ProxyPassReverse  /   http://127.0.0.1:8080/
+
+
+  # Use separate log files for the SSL virtual host; note that LogLevel
+  # is not inherited from httpd.conf.
+  ErrorLog logs/ssl_error_log
+  TransferLog logs/ssl_access_log
+  LogLevel info
+
+  #   SSL Engine Switch:
+  #   Enable/Disable SSL for this virtual host.
+  SSLEngine on
+
+  #   SSL Protocol support:
+  # List the enable protocol levels with which clients will be able to
+  # connect.  Disable SSLv2 access by default:
+  SSLProtocol all -SSLv2 -SSLv3
+
+  #   SSL Cipher Suite:
+  #   List the ciphers that the client is permitted to negotiate.
+  #   See the mod_ssl documentation for a complete list.
+  SSLCipherSuite HIGH:3DES:!aNULL:!MD5:!SEED:!IDEA
+
+  #   Speed-optimized SSL Cipher configuration:
+  #   If speed is your main concern (on busy HTTPS servers e.g.),
+  #   you might want to force clients to specific, performance
+  #   optimized ciphers. In this case, prepend those ciphers
+  #   to the SSLCipherSuite list, and enable SSLHonorCipherOrder.
+  #   Caveat: by giving precedence to RC4-SHA and AES128-SHA
+  #   (as in the example below), most connections will no longer
+  #   have perfect forward secrecy - if the server's key is
+  #   compromised, captures of past or future traffic must be
+  #   considered compromised, too.
+  #SSLCipherSuite RC4-SHA:AES128-SHA:HIGH:MEDIUM:!aNULL:!MD5
+  #SSLHonorCipherOrder on
+
+  #   Server Certificate:
+  # Point SSLCertificateFile at a PEM encoded certificate.  If
+  # the certificate is encrypted, then you will be prompted for a
+  # pass phrase.  Note that a kill -HUP will prompt again.  A new
+  # certificate can be generated using the genkey(1) command.
+  SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+
+  #   Server Private Key:
+  #   If the key is not combined with the certificate, use this
+  #   directive to point at the key file.  Keep in mind that if
+  #   you've both a RSA and a DSA private key you can configure
+  #   both in parallel (to also allow the use of DSA ciphers, etc.)
+  SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+
+  #   Server Certificate Chain:
+  #   Point SSLCertificateChainFile at a file containing the
+  #   concatenation of PEM encoded CA certificates which form the
+  #   certificate chain for the server certificate. Alternatively
+  #   the referenced file can be the same as SSLCertificateFile
+  #   when the CA certificates are directly appended to the server
+  #   certificate for convinience.
+  #SSLCertificateChainFile /etc/pki/tls/certs/server-chain.crt
+
+  #   Certificate Authority (CA):
+  #   Set the CA certificate verification path where to find CA
+  #   certificates for client authentication or alternatively one
+  #   huge file containing all of them (file must be PEM encoded)
+  #SSLCACertificateFile /etc/pki/tls/certs/ca-bundle.crt
+
+  #   Client Authentication (Type):
+  #   Client certificate verification type and depth.  Types are
+  #   none, optional, require and optional_no_ca.  Depth is a
+  #   number which specifies how deeply to verify the certificate
+  #   issuer chain before deciding the certificate is not valid.
+  #SSLVerifyClient require
+  #SSLVerifyDepth  10
+
+  #   Access Control:
+  #   With SSLRequire you can do per-directory access control based
+  #   on arbitrary complex boolean expressions containing server
+  #   variable checks and other lookup directives.  The syntax is a
+  #   mixture between C and Perl.  See the mod_ssl documentation
+  #   for more details.
+  #<Location />
+  #SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
+  #            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
+  #            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
+  #            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
+  #            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
+  #           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
+  #</Location>
+
+  #   SSL Engine Options:
+  #   Set various options for the SSL engine.
+  #   o FakeBasicAuth:
+  #     Translate the client X.509 into a Basic Authorisation.  This means that
+  #     the standard Auth/DBMAuth methods can be used for access control.  The
+  #     user name is the `one line' version of the client's X.509 certificate.
+  #     Note that no password is obtained from the user. Every entry in the user
+  #     file needs this password: `xxj31ZMTZzkVA'.
+  #   o ExportCertData:
+  #     This exports two additional environment variables: SSL_CLIENT_CERT and
+  #     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+  #     server (always existing) and the client (only existing when client
+  #     authentication is used). This can be used to import the certificates
+  #     into CGI scripts.
+  #   o StdEnvVars:
+  #     This exports the standard SSL/TLS related `SSL_*' environment variables.
+  #     Per default this exportation is switched off for performance reasons,
+  #     because the extraction step is an expensive operation and is usually
+  #     useless for serving static content. So one usually enables the
+  #     exportation for CGI and SSI requests only.
+  #   o StrictRequire:
+  #     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
+  #     under a "Satisfy any" situation, i.e. when it applies access is denied
+  #     and no other module can change it.
+  #   o OptRenegotiate:
+  #     This enables optimized SSL connection renegotiation handling when SSL
+  #     directives are used in per-directory context.
+  #SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+  <Files ~ "\.(cgi|shtml|phtml|php3?)$">
+  SSLOptions +StdEnvVars
+  </Files>
+  <Directory "/var/www/cgi-bin">
+  SSLOptions +StdEnvVars
+  </Directory>
+
+  #   SSL Protocol Adjustments:
+  #   The safe and default but still SSL/TLS standard compliant shutdown
+  #   approach is that mod_ssl sends the close notify alert but doesn't wait for
+  #   the close notify alert from client. When you need a different shutdown
+  #   approach you can use one of the following variables:
+  #   o ssl-unclean-shutdown:
+  #     This forces an unclean shutdown when the connection is closed, i.e. no
+  #     SSL close notify alert is send or allowed to received.  This violates
+  #     the SSL/TLS standard but is needed for some brain-dead browsers. Use
+  #     this when you receive I/O errors because of the standard approach where
+  #     mod_ssl sends the close notify alert.
+  #   o ssl-accurate-shutdown:
+  #     This forces an accurate shutdown when the connection is closed, i.e. a
+  #     SSL close notify alert is send and mod_ssl waits for the close notify
+  #     alert of the client. This is 100% SSL/TLS standard compliant, but in
+  #     practice often causes hanging connections with brain-dead browsers. Use
+  #     this only for browsers where you know that their SSL implementation
+  #     works correctly.
+  #   Notice: Most problems of broken clients are also related to the HTTP
+  #   keep-alive facility, so you usually additionally want to disable
+  #   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+  #   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+  #   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+  #   "force-response-1.0" for this.
+  BrowserMatch "MSIE [2-5]" \
+  nokeepalive ssl-unclean-shutdown \
+  downgrade-1.0 force-response-1.0
+
+  #   Per-Server Logging:
+  #   The home of a custom SSL log file. Use this when you want a
+  #   compact non-error SSL logfile on a virtual host basis.
+  CustomLog logs/ssl_request_log \
+  "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+
+</VirtualHost>
+

--- a/roles/nginx/tasks/configure.yml
+++ b/roles/nginx/tasks/configure.yml
@@ -1,7 +1,7 @@
 - name: 'Configure NGINX'
   become: yes
   template:
-    src: nginx.conf.j2
+    src: anet.conf.j2
     dest: /etc/nginx/nginx.conf
     owner: root
     group: root

--- a/roles/nginx/tasks/stop.yml
+++ b/roles/nginx/tasks/stop.yml
@@ -1,0 +1,5 @@
+- name: Stop NGINX systemd service
+  become: yes
+  service:
+    name: nginx
+    state: stopped

--- a/roles/nginx/tasks/uninstall.yml
+++ b/roles/nginx/tasks/uninstall.yml
@@ -1,0 +1,11 @@
+- name: Disable NGINX systemd service
+  become: yes
+  service:
+    name: nginx
+    enabled: no
+
+- name: Remove NGINX
+  become: yes
+  yum:
+    name: nginx
+    state: removed

--- a/roles/pgadmin/tasks/install.yml
+++ b/roles/pgadmin/tasks/install.yml
@@ -1,0 +1,15 @@
+# Install pgAdmin on RedHat / CentOS 7.x
+
+- name: Install pgAdmin
+  become: yes
+  yum:
+    name:
+      - pgadmin4-web
+      - httpd-tools
+      - policycoreutils-python
+
+    state: latest
+  register: install_pgadmin
+
+- name: Please run `/usr/pgadmin4/bin/setup-web.sh`, and follow the instructions.
+  pause:


### PR DESCRIPTION
Makes pgAdmin accessible via `https://anet/pgadmin4`.

Allows remote database management, e.g. executing queries.

Caveats:
1. User authentication directly handled by [pgadmin4](https://www.pgadmin.org/). [pgadmin4](https://www.pgadmin.org/) it seems to only support LDAP, which I don't think can be proxies via [Keycloak](https://www.keycloak.org/).
2. Apache internally reverse proxying access to [pgadmin4](https://www.pgadmin.org/). I tried to map straight access into the application, but the proxy rules seem to overrule everything else within SSL virtual host.

* [ ] Merge #25 (switching to Apache) first.