### PR TITLE
Install latest ANET from repository

### DIFF
--- a/roles/anet/defaults/main.yml
+++ b/roles/anet/defaults/main.yml
@@ -2,7 +2,6 @@ anet_installation_folder: /opt
 anet_application_folder: '{{anet_installation_folder}}/anet'
 anet_version: 2.1.33~135~gfa4b24306
 anet_db_host: localhost
-anet_rpm: 'anet-{{anet_version}}-2'
 
 source_rpm_folder: '{{local_artifact_folder}}'
 remote_rpm_folder: '{{remote_artifact_folder}}'

--- a/roles/anet/tasks/install.yml
+++ b/roles/anet/tasks/install.yml
@@ -4,8 +4,7 @@
 - name: Install ANET
   become: yes
   yum:
-    name:
-      - '{{ anet_rpm }}'
+    name: anet
     state: present
 
 - name: 'Register ANET systemd script'


### PR DESCRIPTION
Remove explicit version from ANET rpm, which is not required using a repository.
